### PR TITLE
Update Uncook.cs

### DIFF
--- a/WolvenKit.Modkit/RED4/Uncook.cs
+++ b/WolvenKit.Modkit/RED4/Uncook.cs
@@ -955,7 +955,7 @@ namespace WolvenKit.Modkit.RED4
             SaveMaterials(outfile, materialDataToExport);
             _SaveMeshes(outfile, modelsAndRigsCombinedToExport);
 
-            _loggerService.Info($"Mesh export completed, {meshesToExport.Count} meshes, {materialDataToExport.Count} materials, {rigsCombinedToExport?.Names?.Length ?? 0} rigs");
+            _loggerService.Info($"Mesh export completed, {meshesToExport.Count} meshes, {materialDataToExport.Count} materials, {rigsCombinedToExport?.Names?.Length ?? 0} bones");
             return true;
 
 


### PR DESCRIPTION
Output message stated rigs when it meant bones.


Fixed:
- when you do a multimesh export with the new exporter it tells you its exported X rigs when it means bones.
